### PR TITLE
Fix MountFiles

### DIFF
--- a/web/server.py
+++ b/web/server.py
@@ -61,9 +61,14 @@ class MountFiles(StaticFiles):
 
     async def get_response(self, path, scope):
         """Rewrite to / if 404"""
-        response = await super().get_response(path, scope)
-        if response.status_code != 404:
-            return response
+        try:
+            response = await super().get_response(path, scope)
+            if response.status_code != 404:
+                return response
+        except Exception:
+            pass
+
+        # Returns `/`
         return await super().get_response("", scope)
 
 


### PR DESCRIPTION
いつからか FastAPI の StaticFiles は 404 をオブジェクトではなく例外で返すようになっていた
（正確には、オブジェクトで帰す場合と例外で返す場合が混ざっている）
例外であることも前提にしてコードを修正する